### PR TITLE
Process improvements: add personas and checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 
+---
+
+Guía adicional
+
+- Para aprender a usar Copilot Spaces en este proyecto y centralizar el conocimiento del equipo, visita: [docs/Copilot Spaces Guide](docs/copilot-spaces-guide.md)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ Docs in this folder (entry points)
 - docs/octoacme-retrospective-and-continuous-improvement.md
 - docs/octoacme-roles-and-personas.md
 
+- docs/copilot-spaces-guide.md
+
 How to use this README
 - Use this file as the landing page for program-level process docs.
 - Keep the Project One‑pager and release README updated in each project repo.

--- a/docs/copilot-spaces-guide.md
+++ b/docs/copilot-spaces-guide.md
@@ -1,0 +1,89 @@
+## Guía rápida: Escalar conocimiento institucional con Copilot Spaces
+
+Esta guía explica cómo usar Copilot Spaces para centralizar, compartir y mantener el conocimiento del proyecto (políticas, procesos, plantillas y respuestas frecuentes) de forma colaborativa.
+
+Objetivo
+- Facilitar que el equipo encuentre respuestas rápidas y actualizadas.
+- Reducir la carga de repetición en entrevistas y onboarding.
+
+¿Qué encontrarás aquí?
+- Cómo estructurar un Space para documentación operativa.
+- Plantillas de issues/PRs y pages para la base de conocimiento.
+- Ejemplos de prompts y flujos de trabajo recomendados.
+
+1) Estructura recomendada del Space
+- Home: visión, enlaces rápidos y responsables.
+- Procesos: planificación, ejecución, QA, despliegue.
+- Plantillas: issues, PRs, runbooks, checklist de release.
+- Preguntas frecuentes (FAQ) y atajos de troubleshooting.
+- Historial de cambios y responsables por sección.
+
+2) Roles y permisos
+- Owner: mantiene la estructura y revisa cambios semestrales.
+- Editors: equipos que actualizan procesos y runbooks.
+- Viewers: resto del equipo.
+
+3) Plantillas útiles (copiar/pegar)
+
+- Plantilla de issue - Añadir/Actualizar documento
+
+```
+Título: [docs] Actualizar <nombre-del-doc> — motivo
+
+Descripción:
+- ¿Qué se cambia? (resumen)
+- Motivación o enlace a la discusión
+- Impacto / stakeholders
+
+Checklist:
+- [ ] Redacción revisada
+- [ ] Owner asignado
+- [ ] Enlace en README principal actualizado
+```
+
+- Plantilla de PR - Cambios en docs
+
+```
+Resumen del cambio
+
+Files changed:
+- docs/<archivo.md>
+
+Notas para el revisor:
+- Comprueba consistencia de tono y enlaces
+
+Relacionado con: #issue
+```
+
+4) Ejemplos de prompts (para usar dentro del Space o con Copilot)
+- "Resume este runbook en 3 bullets para un onboarding rápido."
+- "Genera una checklist de pre-release basada en este documento: <enlace>."
+- "Detecta y sugiere titulares claros para esta página larga." 
+
+5) Flujo mínimo recomendado para cambios en la KB
+1. Crear issue con la plantilla "Actualizar documento".
+2. Asignar owner y deadline corto (p.ej. 3 días).
+3. Abrir PR con cambios y referencias.
+4. Revisar (1 reviewer) y mergear.
+5. Actualizar el índice en `docs/README.md` y la sección de changelog.
+
+6) Buenas prácticas
+- Citar fuentes y decisiones: siempre enlaza la issue/PR que motivó el cambio.
+- Pequeños commits: facilita revisiones rápidas.
+- Revisiones periódicas: programar auditoría trimestral de pages críticas.
+- Uso de etiquetas: `process`, `runbook`, `template`, `stale`.
+
+7) Plantilla de auditoría trimestral (short)
+- Lista de páginas críticas
+- Última modificación
+- Responsable
+- Acción sugerida (actualizar/archivar)
+
+Próximos pasos sugeridos
+- Crear un Space de prueba y migrar 2-3 documentos clave.
+- Documentar el owner y el proceso de cambios en la página Home del Space.
+
+Contacto
+- Para dudas sobre esta guía: abrir issue en este repo con la etiqueta `copilot-spaces`.
+
+© 2025 — Guía generada para el ejercicio "Scale institutional knowledge using Copilot Spaces".

--- a/docs/octoacme-documentation-checklist.md
+++ b/docs/octoacme-documentation-checklist.md
@@ -1,0 +1,24 @@
+```markdown
+# OctoAcme — Documentation Checklist
+
+Purpose: ensure documentation is accurate, discoverable, and included in the Definition of Done.
+
+For each feature/PR:
+- [ ] Identify required docs (user-facing, API, runbook, internal)
+- [ ] Create or update documentation files in docs/ or designated repo path
+- [ ] Include documentation reviews in PR checklist (SME & Technical Writer)
+- [ ] Link published docs in the issue / PR description
+- [ ] Update TOC / index if new doc added
+- [ ] Verify examples and code snippets are valid
+
+Release documentation:
+- [ ] Draft release notes (summary, notable changes, migration steps)
+- [ ] Add known issues and mitigation steps
+- [ ] Publish notes to stakeholders and external channels
+
+Owners:
+- Technical Writer: drafts and coordinates reviews
+- Developers: provide technical accuracy and code examples
+- QA: validate steps that relate to acceptance/testing
+- PM/PdM: approve customer-facing messaging
+```

--- a/docs/octoacme-release-checklist.md
+++ b/docs/octoacme-release-checklist.md
@@ -1,0 +1,35 @@
+```markdown
+# OctoAcme — Release Checklist
+
+Purpose: a concise pre-release and post-release checklist to reduce risk and make releases consistent.
+
+Pre-release (must be completed before a release is approved)
+- [ ] All PRs merged and linked to issues with acceptance criteria
+- [ ] CI green for all merged changes; security scans passed
+- [ ] Integration and smoke tests executed in staging
+- [ ] Rollback plan documented and validated
+- [ ] Release notes drafted and reviewed (Technical Writer + PdM)
+- [ ] Release window scheduled and communicated to stakeholders
+- [ ] Support / On-call notified and runbooks updated
+- [ ] Feature flags and rollout plan defined (if applicable)
+- [ ] Release Manager approval obtained
+
+Deployment
+- [ ] Backup / snapshot (if applicable)
+- [ ] Automated pipeline executed or manual steps followed
+- [ ] Post-deploy smoke tests executed
+- [ ] Verify key metrics and health checks
+
+Post-release
+- [ ] Confirm success with stakeholders and support
+- [ ] Publish release notes to external/internal channels
+- [ ] Update the Risk Register with any new observations
+- [ ] Capture any follow-up action items and owners
+- [ ] Retrospective entry (if release had notable issues)
+
+Roles typically responsible (example)
+- Release Manager: overall owner of checklist
+- Developers / QA: validation and post-deploy verification
+- Technical Writer: release notes
+- PM / PdM: stakeholder communication and success validation
+```

--- a/docs/octoacme-requirements-checklist.md
+++ b/docs/octoacme-requirements-checklist.md
@@ -1,0 +1,20 @@
+```markdown
+# OctoAcme — Requirements & Acceptance Criteria Checklist
+
+Purpose: ensure backlog items are ready for development and testable.
+
+Item readiness:
+- [ ] Clear title and brief description
+- [ ] Measurable acceptance criteria defined
+- [ ] Business outcome / success metric specified
+- [ ] Dependencies and constraints listed
+- [ ] Estimates / sizing provided
+- [ ] Owner assigned (PdM / BA)
+- [ ] UX mockups or API contracts attached (if applicable)
+- [ ] Security/privacy impacts assessed
+
+When done:
+- [ ] QA test cases identified
+- [ ] Documentation needs identified and assigned
+- [ ] Release impacts noted (setting expectations with Release Manager)
+```

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,6 +1,9 @@
+```markdown
 # OctoAcme Personas
 
 This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
+It has been expanded to include additional personas and clear interaction patterns to reduce ambiguity
+and improve accountability during planning, execution, releases, and documentation.
 
 ---
 
@@ -75,7 +78,95 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
-## How these personas are used in the exercise
-- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
-- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
+## (New) Release Manager
 
+### Role Summary
+Coordinates and owns the release pipeline and schedule for a project or product area. Focuses on reducing deployment risk and ensuring release readiness.
+
+### Responsibilities
+- Create and maintain release schedule and cutover plans
+- Ensure pre-release requirements are met (CI, tests, rollbacks, release notes)
+- Coordinate cross-team release activities (QA, infra, support, documentation)
+- Lead release readiness checks and post-release verification
+- Maintain rollback and mitigation playbooks
+
+### Interaction
+- Works closely with PM for scheduling and stakeholder communication
+- Collaborates with Developers and QA to validate readiness
+- Partners with Technical Writer for release notes and communications
+- Notifies Support and On-call teams prior to release windows
+
+---
+
+## (New) Scrum Master
+
+### Role Summary
+Supports teams practicing agile methods by facilitating ceremonies, removing impediments, and helping the team improve its delivery process.
+
+### Responsibilities
+- Facilitate sprint ceremonies (planning, daily standup, review, retrospective)
+- Track and remove team blockers or escalate where needed
+- Coach the team on agile practices, flow, and continuous improvement
+- Help maintain a healthy sprint backlog and support estimation sessions
+
+### Interaction
+- Works with Project Manager to align delivery cadence and escalations
+- Supports Developers and QA to improve flow and throughput
+- Coordinates with Product Manager to ensure backlog readiness
+
+---
+
+## (New) Technical Writer
+
+### Role Summary
+Produces and maintains user-facing and internal documentation required for adoption, support, and compliance.
+
+### Responsibilities
+- Draft and maintain release notes, user guides, runbooks, and API docs
+- Ensure documentation is updated as part of the Definition of Done
+- Coordinate reviews with SMEs (Developers, QA, PM)
+- Maintain a documentation checklist and publishing workflow
+
+### Interaction
+- Works with Developers and QA to verify accuracy
+- Collaborates with Release Manager to publish release notes
+- Partners with Product Manager to align documentation with product messaging
+
+---
+
+## (New) Business Analyst
+
+### Role Summary
+Bridges stakeholders and the delivery team by refining requirements, creating acceptance criteria, and defining measurable outcomes.
+
+### Responsibilities
+- Elicit, document, and validate functional and non-functional requirements
+- Define acceptance criteria and success metrics for backlog items
+- Model business flows and help identify edge cases
+- Support stakeholder alignment and clarify priority trade-offs
+
+### Interaction
+- Works with Product Manager to translate vision into backlog items
+- Engages Developers and QA to ensure requirements are actionable and testable
+- Coordinates with Project Manager to surface dependency impacts
+
+---
+
+## Interaction patterns & responsibility mapping
+
+- Planning
+  - Product Manager (PdM) owns backlog prioritization; Business Analyst refines requirements; Project Manager ensures timelines; Scrum Master organizes planning.
+- Execution
+  - Developers implement work; QA validates; Technical Writer updates documentation as part of DoD; Scrum Master removes impediments.
+- Release
+  - Release Manager owns schedule and readiness checks; Developers and QA complete verification; Technical Writer publishes release notes; Project Manager informs stakeholders.
+- Escalation
+  - Team -> Scrum Master / PM -> Product Lead -> Sponsor. For security incidents follow the security runbook and notify Security on-call.
+
+---
+
+## How to use these personas
+- Use these persona definitions to clarify handoffs in project plans and checklists.
+- Add role assignments to the Project One-pager and to backlog items (Owner field).
+- For exercises and Copilot prompts, use these persona summaries to simulate stakeholder perspectives.
+```


### PR DESCRIPTION
This PR expands the roles-and-personas doc to include Release Manager, Scrum Master, Technical Writer, and Business Analyst and adds three checklists (release, documentation, requirements). These updates address gaps identified in issue #4 and clarify owners and handoffs.